### PR TITLE
yahengsu/upload to inventory and some bug fixes

### DIFF
--- a/commands/show_inventory.js
+++ b/commands/show_inventory.js
@@ -9,6 +9,7 @@ const {
 
 const help =
   'To view augs in your inventory, type `!inventory [username]`.';
+const predicate = message => message.content.startsWith('!inventory');
 
 const execute = async (message) => {
   const username = message.content.split(' ')[1];
@@ -33,4 +34,4 @@ const execute = async (message) => {
   });
 };
 
-module.exports = {name, help, execute};
+module.exports = {name, help, predicate, execute};

--- a/commands/show_inventory.js
+++ b/commands/show_inventory.js
@@ -12,7 +12,11 @@ const help =
 const predicate = message => message.content.startsWith('!inventory') && message.attachments.size === 0;
 
 const execute = async (message) => {
-  const username = message.content.split(' ')[1];
+  const args = message.content.split(' ').slice(1);
+  const [username] = args;
+  if (!username) {
+    return message.reply('Please enter a username!');
+  }
   const res = await fetch(`${BASE_USER_URL}${username}`);
   const resp = await res.json();
 

--- a/commands/show_inventory.js
+++ b/commands/show_inventory.js
@@ -9,7 +9,7 @@ const {
 
 const help =
   'To view augs in your inventory, type `!inventory [username]`.';
-const predicate = message => message.content.startsWith('!inventory');
+const predicate = message => message.content.startsWith('!inventory') && message.attachments.size === 0;
 
 const execute = async (message) => {
   const username = message.content.split(' ')[1];

--- a/commands/upload.js
+++ b/commands/upload.js
@@ -5,8 +5,8 @@ const {extract} = require('../utils');
 
 const {PACKAGE_NAME_REGEX, BASE_IPFS_URL} = require('../constants');
 const name = 'upload';
-const help = 'To upload an XRPackage, send a .wbn file as an attachment to a message with "!upload"';
-const predicate = message => message.attachments && message.content.startsWith('!upload');
+const help = 'To upload an XRPackage, send a `.wbn` file as an attachment to a message with `!upload`';
+const predicate = message => message.attachments.size > 0 && message.content.startsWith('!upload');
 
 async function uploadPackage(xrpkUrl, xrpkName) {
   const res = await fetch(xrpkUrl);

--- a/commands/upload.js
+++ b/commands/upload.js
@@ -91,4 +91,4 @@ const execute = async message => {
   }
 };
 
-module.exports = {name, help, predicate, execute};
+module.exports = {name, help, predicate, execute, uploadPackage};

--- a/commands/upload_to_inventory.js
+++ b/commands/upload_to_inventory.js
@@ -1,0 +1,16 @@
+const fetch = require('node-fetch');
+
+const {BASE_INSPECT_URL, BASE_USER_URL} = require('../constants');
+
+const name = 'upload-to-inventory';
+
+const help = 'To upload a package from your computer to your inventory, type `!inv [username]` when uploading a `.wbn` file.';
+
+const execute = async message => {
+    const username = message.content.split(' ')[1];
+    const res = await fetch(`${BASE_USER_URL}${username}`);
+    const resp = res.json();
+    
+};
+
+module.exports = {name, help, execute};

--- a/commands/upload_to_inventory.js
+++ b/commands/upload_to_inventory.js
@@ -10,8 +10,11 @@ const predicate = (message) =>
   message.attachments.size > 0 && message.content.startsWith('!inventory');
 
 const execute = async (message) => {
-  const username = message.content.split(' ')[1];
-
+  const args = message.content.split(' ').slice(1);
+  const [username] = args;
+  if (!username) {
+    return message.reply('Please enter a username!');
+  }
   const wbnAttachment = message.attachments.values().next().value;
   const fileName = wbnAttachment.name;
   const ipfsUrl = wbnAttachment.attachment;
@@ -28,6 +31,7 @@ const execute = async (message) => {
       console.log(`userObj Error: ${userObj.error}`);
       return message.reply(`Unable to find a user named \`${username}\`.`);
     }
+
     userObj.inventory.push({
       name: uploadData.metadata.name,
       hash: uploadData.metadata.dataHash,

--- a/commands/upload_to_inventory.js
+++ b/commands/upload_to_inventory.js
@@ -1,16 +1,71 @@
 const fetch = require('node-fetch');
-
+const {uploadPackage} = require('./upload');
 const {BASE_INSPECT_URL, BASE_USER_URL} = require('../constants');
 
 const name = 'upload-to-inventory';
 
-const help = 'To upload a package from your computer to your inventory, type `!inv [username]` when uploading a `.wbn` file.';
+const help =
+  'To upload a package from your computer to your inventory, type `!inv [username]` when uploading a `.wbn` file.';
+const predicate = (message) =>
+  message.attachments && message.content.startsWith('!inv');
 
-const execute = async message => {
-    const username = message.content.split(' ')[1];
-    const res = await fetch(`${BASE_USER_URL}${username}`);
-    const resp = res.json();
-    
+const execute = async (message) => {
+  console.log(`MESSAGE: ${message.content}`);
+  const username = message.content.split(' ')[1];
+
+  const wbnAttachment = message.attachments.values().next().value;
+  const fileName = wbnAttachment.name;
+  const ipfsUrl = wbnAttachment.attachment;
+  if (!fileName.endsWith('.wbn')) {
+    return message.reply("Please make sure you're uploading a `.wbn` file!");
+  }
+
+  try {
+    message.reply('Attempting to upload package to inventory...');
+    const uploadData = await uploadPackage(ipfsUrl, fileName);
+    console.log('FINISHED UPLOAD DATA');
+    const user = await fetch(`${BASE_USER_URL}${username}`);
+    const userObj = await user.json();
+    console.log(userObj);
+    if (userObj.error) {
+      return message.reply(`Unable to find a user named \`${username}\`.`);
+    }
+    console.log(userObj);
+    userObj.inventory.push({
+      name: uploadData.metadata.name,
+      hash: uploadData.metadata.dataHash,
+      iconHash: uploadData.metadata.icons[0].hash,
+    });
+    console.log(userObj);
+    console.log(JSON.stringify(userObj));
+    const res = await fetch(`${BASE_USER_URL}${username}`, {
+      method: 'PUT',
+      body: JSON.stringify(userObj),
+    });
+
+    const resp = await res.json();
+
+    if (!resp.ok) {
+      console.log(resp);
+      return message.reply(
+        `Error updating user inventory for \`${username}\`.`,
+      );
+    }
+
+    message.channel.send({
+      embed: {
+        title: `Uploaded "${uploadData.metadata.name}" to ${username}'s inventory!`,
+        url: `${BASE_INSPECT_URL}?p=${uploadData.metadata.name}`,
+        fields: [
+          {name: 'name', value: uploadData.metadata.name},
+          {name: 'hash', value: uploadData.metadata.dataHash},
+        ],
+      },
+    });
+  } catch (err) {
+    console.log(`Error uploading package ${fileName} to  IPFS: ${err.message}`);
+    message.reply(`There was an error uploading your package: ${err.message}`);
+  }
 };
 
-module.exports = {name, help, execute};
+module.exports = {name, help, predicate, execute};

--- a/constants.js
+++ b/constants.js
@@ -1,7 +1,7 @@
 const BASE_INSPECT_URL = 'https://xrpackage.org/inspect.html';
 const BASE_IPFS_URL = 'https://ipfs.exokit.org/ipfs/';
 const BASE_API_URL = 'http://packages.exokit.org/';
-const PACKAGE_NAME_REGEX = /^[a-z0-9][a-z0-9-._~]*$/;
+const PACKAGE_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-._~]*$/;
 const BASE_USER_URL = 'https://users.exokit.org/';
 
 module.exports = {

--- a/constants.js
+++ b/constants.js
@@ -1,7 +1,7 @@
 const BASE_INSPECT_URL = 'https://xrpackage.org/inspect.html';
 const BASE_IPFS_URL = 'https://ipfs.exokit.org/ipfs/';
 const BASE_API_URL = 'http://packages.exokit.org/';
-const PACKAGE_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-._~]*$/;
+const PACKAGE_NAME_REGEX = /^[a-z0-9][a-z0-9-._~]*$/;
 const BASE_USER_URL = 'https://users.exokit.org/';
 
 module.exports = {


### PR DESCRIPTION
Added upload to inventory functionality with the `!inventory [username]` command when uploading a .wbn file. PR also addresses some small bugs. Since the inventory is a collection of aug hashes and names, packages are uploaded to IPFS first and then the user object is updated to include the name and hash of the package.

Changes:

- Added upload to inventory feature
- Fix package regex not including uppercase letters
- Check `message.attachments.size` instead of `message.attachments` (message.attachments always has a collection, defaults to true)
- Some text changes (wrapping some keywords with `tickmarks`) to be more in line with current `!help` style
